### PR TITLE
Add Gmail SMTP email sending with environment-based configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,9 @@
+# Your Gmail address (the sender)
+EMAIL_ADDRESS=your-email@gmail.com
+
+# Your Gmail App Password (16 characters)
+# How to get this is explained in the README.
+EMAIL_KEY="xxxx xxxx xxxx xxxx"
+
+# The recipient's email address
+EMAIL_RECEIVER=recipient@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Dependency directories (uncomment if you want to ignore vendor directory)
+# vendor/
+
+# Build output directory
+bin/
+
+# IDE and editor specific files
+.idea/
+.vscode/
+*.sublime-project
+*.sublime-workspace
+.DS_Store # macOS specific
+.env

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ By default, a demo API key is included. For higher limits or production use:
 ```go
     const apiKey = your_key_here
 ```
-
+### Email Sender
+see [this](./massager/ReadMe.md) for more information
 ## 🔧 Installation
 
 Clone the repo:
 
 ```bash
 git clone https://github.com/Maryam-nokohan/GoldCurrentPrice.git
-go run goldPri.go
+cd GoldCurrentPrice
+go mod tidy
+go run .
+```

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"log"
+	"os"
+
+	"github.com/joho/godotenv"
+)
+
+func init(){
+	log.Println("Loading .env")
+	Load(".env")
+}
+
+func GetFromEnv(key string) string {
+	return os.Getenv(key)
+}
+
+func Load(file string){
+	err := godotenv.Load(file)
+	if err != nil {
+		log.Printf("Error in loading .env : %s\n", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/Maryam-nokohan/GoldCurrentPrice
+
+go 1.24.5
+
+require (
+	github.com/joho/godotenv v1.5.1
+	gopkg.in/mail.v2 v2.3.1
+)
+
+require gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
+gopkg.in/mail.v2 v2.3.1 h1:WYFn/oANrAGP2C0dcV6/pbkPzv8yGzqTjPmTeO7qoXk=
+gopkg.in/mail.v2 v2.3.1/go.mod h1:htwXN1Qh09vZJ1NVKxQqHPBaCBbzKhp5GzuJEA4VJWw=

--- a/goldPri.go
+++ b/goldPri.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/Maryam-nokohan/GoldCurrentPrice/config"
+	"github.com/Maryam-nokohan/GoldCurrentPrice/massager"
+	"github.com/Maryam-nokohan/GoldCurrentPrice/model"
 )
 
 const apiKey = "goldapi-10mc7psmd7stwiu-io"
@@ -51,4 +55,12 @@ func main() {
 	}
 
 	fmt.Printf("Current gold price in USD: $%.2f\n", price)
+
+	// Mail sender logic
+	sender := massager.NewMail(config.GetFromEnv("EMAIL_ADDRESS"), config.GetFromEnv("EMAIL_KEY"))
+	sender.Send(config.GetFromEnv("EMAIL_RECEIVER") , &model.Message{
+		Header: "Gold current price",
+		Body: fmt.Sprintf("hello\nthe current price of gold in USD is %.2f\n" , price),
+	})
+
 }

--- a/massager/ReadMe.md
+++ b/massager/ReadMe.md
@@ -24,5 +24,17 @@ This is how you can get gmail App password for this program. This methode is sec
 5. Click **Generate**.
 6. Copy the 16-character password Google shows you (it will look like `abcd efgh ijkl mnop`).
 
+## 3. Add info to .env
+```
+# Your Gmail address (the sender)
+EMAIL_ADDRESS=your-email@gmail.com
+
+# Your Gmail App Password (16 characters)
+# How to get this is explained in the README.
+EMAIL_KEY="xxxx xxxx xxxx xxxx"
+
+# The recipient's email address
+EMAIL_RECEIVER=recipient@example.com
+```
 
 

--- a/massager/ReadMe.md
+++ b/massager/ReadMe.md
@@ -1,0 +1,28 @@
+# Gmail SMTP Email Sender in Go
+
+This  sends emails using Gmail's SMTP server in Go.
+It uses a `.env` file to store credentials securely.
+
+
+
+## 1. Prerequisites
+- A Gmail account
+- An App Password (Google no longer allows normal passwords for SMTP)
+
+
+## 2. How to Get a Gmail App Password
+This is how you can get gmail App password for this program. This methode is secure.
+### Step 1 — Enable 2-Step Verification
+1. Go to your [Google Account Security](https://myaccount.google.com/security) page.
+2. Under **"Signing in to Google"**, enable **2-Step Verification**.
+
+### Step 2 — Generate an App Password
+1. After enabling 2-Step Verification, go to [App Passwords](https://myaccount.google.com/apppasswords).
+2. Sign in again if prompted.
+3. Under **Select app**, choose **Mail**.
+4. Under **Select device**, choose **Other (Custom name)** and type `Golang`.
+5. Click **Generate**.
+6. Copy the 16-character password Google shows you (it will look like `abcd efgh ijkl mnop`).
+
+
+

--- a/massager/error.go
+++ b/massager/error.go
@@ -1,0 +1,7 @@
+package massager
+
+import "errors"
+
+var (
+	ErrInSending = errors.New("can't this error")
+)

--- a/massager/interfase.go
+++ b/massager/interfase.go
@@ -1,0 +1,8 @@
+package massager
+
+import "github.com/Maryam-nokohan/GoldCurrentPrice/model"
+
+
+type Massenger interface{
+	Send(to string, message *model.Message)error
+}

--- a/massager/massager.go
+++ b/massager/massager.go
@@ -1,0 +1,43 @@
+package massager
+
+import (
+	"log"
+
+	"github.com/Maryam-nokohan/GoldCurrentPrice/model"
+	gomail "gopkg.in/mail.v2"
+)
+
+type emailMessenger struct {
+	From string
+	Key  string
+}
+
+func NewMail(from, key string) Massenger {
+	if key == "" || from == "" {
+		log.Fatal("key or from is empty")
+	}
+
+	return &emailMessenger{
+		From: from,
+		Key:  key,
+	}
+}
+
+func (e *emailMessenger) Send(to string, message *model.Message) error {
+	msg := gomail.NewMessage()
+
+	msg.SetHeader("From", e.From)
+	msg.SetHeader("To", to)
+	msg.SetHeader("Subject", message.Header)
+	msg.SetBody("text/plain", message.Body)
+
+	dialer := gomail.NewDialer("smtp.gmail.com", 587, e.From, e.Key)
+
+	if err := dialer.DialAndSend(msg); err != nil {
+		log.Println(err)
+		return ErrInSending
+	} else {
+		log.Println("Email sent successfully!")
+	}
+	return nil
+}

--- a/model/message.go
+++ b/model/message.go
@@ -1,0 +1,6 @@
+package model
+
+type Message struct {
+	Header string `json:"header"`
+	Body   string `json:"body"`
+}


### PR DESCRIPTION
## Summary
This PR introduces Gmail SMTP email-sending functionality to the project using environment-based configuration.
It sets up `.env` file handling, Gmail App Password authentication, and a working example in `main`.

## Changes
- Added `.env.sample` for environment variable structure.
- Integrated `github.com/joho/godotenv` to load environment variables.
- Added `gopkg.in/gomail.v2` for SMTP email sending.
- Added `config` package to handle environment configuration loading.
- Added `massager` package for building and sending email messages.
- Added `model` package for defining email-related data structures.
- Updated `README.md` with Gmail App Password setup instructions and `.env` usage.
- Created `.gitignore` entry to prevent committing `.env` to version control.